### PR TITLE
Fix bug on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,10 +99,14 @@ export function version(program, projectPath) {
 						if (!programOpts.skipTag) {
 							log({ text: "Adjusting Git tag..." }, programOpts.quiet);
 
-							child.execSync(
-								"git tag -f $(git tag --sort=v:refname | tail -1)",
-								gitCmdOpts
-							);
+							if (process.platform === "win32") {
+								child.execSync(`git tag -f v${appPkg.version}`, gitCmdOpts);
+							} else {
+								child.execSync(
+									"git tag -f $(git tag --sort=v:refname | tail -1)",
+									gitCmdOpts
+								);
+							}
 						}
 				}
 			}


### PR DESCRIPTION
tail command is not supported on Windows.
I fixed it with the version number available in package json.